### PR TITLE
Refactor to use ubuntu tools

### DIFF
--- a/corbos_scm/command.py
+++ b/corbos_scm/command.py
@@ -72,7 +72,7 @@ class Command:
         output, error = process.communicate()
         if process.returncode != 0 and raise_on_error:
             raise CSCMCommandError(
-                f'stderr: {error!r}, stdout: {output!r}'
+                f'command: {command}, stderr: {error!r}, stdout: {output!r}'
             )
         return command_type(
             output=format(output),

--- a/corbos_scm/corbos_scm.py
+++ b/corbos_scm/corbos_scm.py
@@ -20,23 +20,28 @@
 #
 """
 Usage:
-    corbos_scm --git=<git_clone_source> --outdir=<obs_out>
-        [--package=<package_path>]
-        [--branch=<name>]
+    corbos_scm --package=<name> --registry=<uri> --container=<name> --outdir=<obs_out>
+        [--mirror=<mirror>]
+        [--distribution=<name>]
     corbos_scm -h | --help
     corbos_scm --version
 
 Options:
-    --git=<git_clone_source>
-        git clone location to fetch packages sources.
-        It is expected that the sources are stored in a format
-        matching the EB Corbos Linux project.
+    --package=<name>
+        Name of package to fetch
 
-    --package=<package_path>
-        Path to package relative to --git root [default: .]
+    --mirror=<mirror>
+        Preferred mirror(s)
 
-    --branch=<name>
-        Branch in git source.
+    --distribution=<name>
+        Pull from: debian, ubuntu
+
+    --registry=<uri>
+        Container registry URI
+
+    --container=<name>
+        Container name to pull. The container is expected to
+        contain the Debian/Ubuntu development tools
 
     --outdir=<obs_out>
         Output directory to store data produced by the service.
@@ -44,42 +49,13 @@ Options:
         this option is set.
 """
 import os
-import yaml
-import shutil
-import re
 from pathlib import Path
-from typing import (
-    NamedTuple, Dict, Union, List, Any
-)
-from tempfile import TemporaryDirectory
 import docopt
-import hashlib
 
 from corbos_scm.version import __version__
 from corbos_scm.command import Command
 from corbos_scm.exceptions import (
-    exception_handler,
-    CSCMDebianSourceNotFound,
-    CSCMDebianChangelogFormatNotDetected
-)
-
-package_type = NamedTuple(
-    'package_type', [
-        ('name', str),
-        ('epoch', str),
-        ('upstream_version', str),
-        ('debian_revision', str),
-        ('target', str)
-    ]
-)
-
-source_sum_type = NamedTuple(
-    'source_sum_type', [
-        ('md5', str),
-        ('sha1', str),
-        ('sha256', str),
-        ('bytesize', int)
-    ]
+    exception_handler
 )
 
 
@@ -90,239 +66,32 @@ def main() -> None:
     if not os.path.exists(args['--outdir']):
         Path(args['--outdir']).mkdir(parents=True, exist_ok=True)
 
-    temp_git_dir = TemporaryDirectory(prefix='corbos_scm.')
-
-    clone_target = temp_git_dir.name
-    checkout_subdir_name = 'corbos'
-    if args['--package'] == '.':
-        # if no dedicated directory exists for the package
-        # we need to name one for the clone target. This is
-        # needed to allow the tar process to work
-        clone_target = os.path.join(clone_target, checkout_subdir_name)
-        args['--package'] = checkout_subdir_name
-
-    Command.run(
-        ['git', 'clone', args['--git'], clone_target]
-    )
-    Command.run(
-        ['rm', '-rf', f'{clone_target}/.git']
-    )
-
-    if args['--branch']:
-        Command.run(
-            ['git', '-C', clone_target, 'checkout', args['--branch']]
-        )
-
-    package_dir = os.path.join(temp_git_dir.name, args['--package'])
-    debian_dir = os.path.join(package_dir, 'debian')
-
-    if not os.path.isdir(debian_dir):
-        raise CSCMDebianSourceNotFound(
-            f'No debian dir in source: {debian_dir!r}'
-        )
-
-    package_meta = get_package_meta(debian_dir)
-
-    dsc_file = create_dsc_file(
-        debian_dir, package_meta, args['--outdir']
-    )
-
-    create_source_tarballs(
-        package_dir, package_meta, dsc_file, args['--outdir']
-    )
-
-
-def get_package_meta(debian_dir: str) -> package_type:
-    with open(f'{debian_dir}/changelog') as changelog:
-        latest = changelog.readline().strip()
-    changelog_format = re.match(
-        r'([a-zA-Z0-9_\-\.]+) \((.*)\) (.*);', latest
-    )
-    if changelog_format:
-        debian_epoch = '0'
-        debian_revision_and_epoch = changelog_format.group(2).split(':')
-        debian_revision = debian_revision_and_epoch.pop()
-        if debian_revision_and_epoch:
-            debian_epoch = debian_revision_and_epoch[0]
-        debian_revision = changelog_format.group(2).split(':').pop()
-        upstream_version = debian_revision.split('-')[0]
-        return package_type(
-            name=changelog_format.group(1),
-            target=changelog_format.group(3),
-            epoch=debian_epoch,
-            debian_revision=debian_revision,
-            upstream_version=upstream_version
-        )
-    else:
-        raise CSCMDebianChangelogFormatNotDetected(
-            'Unknown format: {latest!r}'
-        )
-
-
-def create_dsc_file(
-    debian_dir: str, package: package_type, outdir: str
-) -> str:
-    dsc_file_name = os.path.join(
-        outdir, f'{package.name}_{package.debian_revision}.dsc'
-    )
-    dsc_data: Dict[str, Union[str, List]] = {
-        'Format': '3.0 (quilt)',
-        'Version': f'{package.epoch}:{package.debian_revision}',
-        'Testsuite': 'autopkgtest'
-    }
-    control_raw = ''
-    with open(f'{debian_dir}/control') as control:
-        # treat the control file input as a yaml syntax.
-        # This is not accurate but was able with less
-        # effort and served the purpose for reading the
-        # information needed in the context of this service.
-        for line in control.readlines():
-            if not line.startswith('#'):
-                if line.startswith(' ') or line.startswith('\t'):
-                    # replace inline yaml control characters with
-                    # an allowed one. This is nasty but helps reading
-                    # the control file as yaml data. The information
-                    # replaced is not used in the output data
-                    line = line.replace(':', ';')
-                control_raw += line
-
-        control_dict = yaml.safe_load(control_raw)
-        control_keys = [
-            'Source',
-            'Architecture',
-            'Maintainer',
-            'Build-Depends',
-            'Build-Depends-Indep',
-            'Standards-Version',
-            'Homepage',
-            'Vcs-Browser',
-            'Vcs-Git'
-        ]
-        for control_key in control_keys:
-            if control_key in control_dict:
-                dsc_data[control_key] = \
-                    control_dict[control_key].replace(';', ':')
-
-    package_list = []
-    binary_list = []
-    with open(f'{debian_dir}/control') as control:
-        control_lines = control.read().split(os.linesep)
-        for control_line in control_lines:
-            if control_line.startswith('Package:'):
-                package_name = control_line.split(':')[1].strip()
-                binary_list.append(package_name)
-                package_list.append(
-                    '{0} {1} {2} {3} arch={4}'.format(
-                        package_name,
-                        'deb',
-                        control_dict.get('Section') or 'none',
-                        control_dict.get('Priority') or 'optional',
-                        control_dict.get('Architecture') or 'any'
-                    )
-                )
-    dsc_data['Binary'] = ','.join(binary_list)
-    dsc_data['Package-List'] = package_list
-
-    with open(dsc_file_name, 'w') as dsc:
-        for key in sorted(dsc_data.keys()):
-            if key == 'Package-List':
-                dsc.write('{0}:{1}'.format(key, os.linesep))
-                for package_name in dsc_data[key]:
-                    dsc.write(' {0}{1}'.format(package_name, os.linesep))
-            else:
-                dsc.write('{0}: {1}{2}'.format(key, dsc_data[key], os.linesep))
-    return dsc_file_name
-
-
-def create_source_tarballs(
-    package_dir: str, package: package_type, dsc_file: str, outdir: str
-) -> None:
-    parent_dir = os.path.dirname(package_dir)
-    shutil.move(
-        f'{package_dir}/debian', parent_dir
-    )
-    debian_tar_file_name = \
-        f'{outdir}/{package.name}_{package.debian_revision}.debian.tar.xz'
     Command.run(
         [
-            'tar', '-C', parent_dir, '-cJf', debian_tar_file_name,
-            'debian'
+            'podman', 'pull',
+            f'{args["--registry"]}/{args["--container"]}'
         ]
     )
-    upstream_name = f'{parent_dir}/{package.name}-{package.upstream_version}'
-    shutil.move(
-        package_dir, upstream_name
+
+    pull_debian_source = [
+        'cd', '/tmp', '&&', 'pull-debian-source'
+    ]
+    if args['--mirror']:
+        pull_debian_source.extend(
+            ['--mirror', args['--mirror']]
+        )
+    if args['--distribution']:
+        pull_debian_source.extend(
+            ['--distro', args['--distribution']]
+        )
+    pull_debian_source.append(
+        args['--package']
     )
-    source_tar_file_name = \
-        f'{outdir}/{package.name}_{package.upstream_version}.orig.tar.gz'
+
     Command.run(
         [
-            'tar', '-C', parent_dir, '-czf', source_tar_file_name,
-            f'{package.name}-{package.upstream_version}'
+            'podman', 'run', '-v', f'{args["--outdir"]}:/tmp',
+            '-ti', '--rm', args["--container"],
+            f'bash -c \"{" ".join(pull_debian_source)}\"'
         ]
     )
-    source_files: Dict[str, source_sum_type] = {}
-    for source_file in [source_tar_file_name, debian_tar_file_name]:
-        sha256_checksum = _calculate_hash_hexdigest(
-            hashlib.sha256(), source_file
-        )
-        sha1_checksum = _calculate_hash_hexdigest(
-            hashlib.sha1(), source_file
-        )
-        md5_checksum = _calculate_hash_hexdigest(
-            hashlib.md5(), source_file
-        )
-        source_files[os.path.basename(source_file)] = source_sum_type(
-            md5=md5_checksum,
-            sha1=sha1_checksum,
-            sha256=sha256_checksum,
-            bytesize=os.path.getsize(source_file)
-        )
-    with open(dsc_file, 'a') as dsc:
-        dsc.write(f'Checksums-Sha1:{os.linesep}')
-        for source_file in source_files:
-            dsc.write(
-                ' {0} {1} {2}{3}'.format(
-                    source_files[source_file].sha1,
-                    source_files[source_file].bytesize,
-                    source_file,
-                    os.linesep
-                )
-            )
-        dsc.write(f'Checksums-Sha256:{os.linesep}')
-        for source_file in source_files:
-            dsc.write(
-                ' {0} {1} {2}{3}'.format(
-                    source_files[source_file].sha256,
-                    source_files[source_file].bytesize,
-                    source_file,
-                    os.linesep
-                )
-            )
-        dsc.write(f'Files:{os.linesep}')
-        for source_file in source_files:
-            dsc.write(
-                ' {0} {1} {2}{3}'.format(
-                    source_files[source_file].md5,
-                    source_files[source_file].bytesize,
-                    source_file,
-                    os.linesep
-                )
-            )
-
-
-def _calculate_hash_hexdigest(
-    digest: Any, filename: str, digest_blocks: int = 128
-) -> str:
-    """
-    Calculates the hash hexadecimal digest for a given file.
-
-    :param func digest: Digest function for hash calculation
-    :param str filename: File to compute
-    :param int digest_blocks: Number of blocks processed at a time
-    """
-    chunk_size = digest_blocks * digest.block_size
-    with open(filename, 'rb') as source:
-        for chunk in iter(lambda: source.read(chunk_size), b''):
-            digest.update(chunk)
-    return digest.hexdigest()

--- a/corbos_scm/corbos_scm.service
+++ b/corbos_scm/corbos_scm.service
@@ -1,14 +1,22 @@
 <service name="corbos_scm">
   <summary>Compose Corbos Source into OBS package sources</summary>
-  <description>The service takes packages sources from the Corbos Linux project and commits them to build in a OBS project</description>
-  <parameter name="git">
-    <description>Git clone location to fetch packages sources</description>
-    <required/>
+  <description>The service takes packages sources from the given distro and puts them into the OBS project</description>
+  <parameter name="mirror">
+    <description>Preferred Mirror location</description>
+  </parameter>
+  <parameter name="distribution">
+    <description>Pull from: debian, ubuntu</description>
   </parameter>
   <parameter name="package">
-    <description>Path to package relative to git root [default: .]</description>
+    <description>Package name</description>
+    <required/>
   </parameter>
-  <parameter name="branch">
-    <description>Branch in git source</description>
+  <parameter name="registry">
+    <description>Container registry URI</description>
+    <required/>
+  </parameter>
+  <parameter name="container">
+    <description>Container name in registry which provides the ubuntu-dev-tools</description>
+    <required/>
   </parameter>
 </service>

--- a/corbos_scm/exceptions.py
+++ b/corbos_scm/exceptions.py
@@ -89,15 +89,3 @@ class CSCMCommandError(CSCMError):
     Exception raised if popen call failed and or command
     execution was not successful
     """
-
-
-class CSCMDebianSourceNotFound(CSCMError):
-    """
-    Exception raised if debian source directory was not found
-    """
-
-
-class CSCMDebianChangelogFormatNotDetected(CSCMError):
-    """
-    Exception raised if debian changelog format could not be parsed
-    """

--- a/package/python-corbos_scm-spec-template
+++ b/package/python-corbos_scm-spec-template
@@ -71,26 +71,18 @@ BuildRequires:  fdupes
 BuildArch:      noarch
 
 %description
-An Open Build Service (OBS) service to manage packages
-sources as they are used by the ElektroBit (EB) Corbos
-Linux system.
+An Open Build Service (OBS) service to manage Debian package sources
 
 # python3-corbos_scm
 %package -n python%{python3_pkgversion}-corbos_scm
 Summary:        Corbos SCM - OBS source service
 Group:          Development/Languages/Python
 Requires:       python%{python3_pkgversion}-docopt
-%if 0%{?ubuntu} || 0%{?debian}
-Requires:       python%{python3_pkgversion}-yaml
-%else
-Requires:       python%{python3_pkgversion}-PyYAML
-%endif
 Requires:       python%{python3_pkgversion}-setuptools
+Requires:       podman
 
 %description -n python%{python3_pkgversion}-corbos_scm
-An Open Build Service (OBS) service to manage packages
-sources as they are used by the ElektroBit (EB) Corbos
-Linux system.
+An Open Build Service (OBS) service to manage Debian package sources
 
 %prep
 %setup -q -n corbos_scm-%{version}

--- a/test/unit/corbos_scm_test.py
+++ b/test/unit/corbos_scm_test.py
@@ -1,7 +1,5 @@
-import logging
-import io
 from mock import (
-    patch, MagicMock, call, Mock
+    patch, call
 )
 from pytest import fixture
 import sys
@@ -17,178 +15,49 @@ class TestCorbosSCM:
     def setup(self):
         sys.argv = [
             sys.argv[0],
-            '--git',
-            'https://git.launchpad.net/ubuntu/+source/curl',
-            '--branch',
-            'develop',
+            '--registry',
+            'registry.example.com',
+            '--container',
+            'ubdevtools:latest',
+            '--package',
+            'curl',
+            '--mirror',
+            'some-mirror',
+            '--distribution',
+            'ubuntu',
             '--outdir',
             'obs_out'
         ]
 
     @patch('sys.exit')
-    @patch('os.path.isdir')
     @patch('os.path.exists')
-    @patch('pathlib.Path.mkdir')
+    @patch('corbos_scm.corbos_scm.Path')
     @patch('corbos_scm.corbos_scm.Command')
-    def test_debian_source_not_found(
-        self, mock_Command, mock_pathlib_mkdir, mock_os_path_exists,
-        mock_os_path_isdir, mock_sys_exit
+    def test_pull_and_run(
+        self, mock_Command, mock_Path,
+        mock_os_path_exists, mock_sys_exit
     ):
         mock_os_path_exists.return_value = False
-        mock_os_path_isdir.return_value = False
-        with self._caplog.at_level(logging.ERROR):
-            main()
-            assert format('CSCMDebianSourceNotFound') in self._caplog.text
-            mock_pathlib_mkdir.assert_called_once_with(
-                parents=True, exist_ok=True
-            )
 
-    @patch('sys.exit')
-    @patch('os.path.isdir')
-    @patch('os.path.exists')
-    @patch('pathlib.Path.mkdir')
-    @patch('corbos_scm.corbos_scm.Command')
-    def test_get_package_meta_no_match(
-        self, mock_Command, mock_pathlib_mkdir, mock_os_path_exists,
-        mock_os_path_isdir, mock_sys_exit
-    ):
-        mock_os_path_exists.return_value = True
-        mock_os_path_isdir.return_value = True
-        with patch('builtins.open', create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            file_handle = mock_open.return_value.__enter__.return_value
-            file_handle.readline.return_value = \
-                'xsnow 42 unstable; urgency=low'
-            with self._caplog.at_level(logging.ERROR):
-                main()
-                assert format(
-                    'CSCMDebianChangelogFormatNotDetected'
-                ) in self._caplog.text
+        main()
 
-    @patch('sys.exit')
-    @patch('yaml.safe_load')
-    @patch('shutil.move')
-    @patch('os.path.isdir')
-    @patch('os.path.exists')
-    @patch('pathlib.Path.mkdir')
-    @patch('corbos_scm.corbos_scm.TemporaryDirectory')
-    @patch('corbos_scm.corbos_scm.Command')
-    @patch('os.path.getsize')
-    def test_source_data_creation(
-        self, mock_os_path_getsize, mock_Command,
-        mock_TemporaryDirectory, mock_pathlib_mkdir,
-        mock_os_path_exists, mock_os_path_isdir, mock_shutil_move,
-        mock_yaml_safe_load, mock_sys_exit
-    ):
-        read_return_tar_chunks = [b'', b'', b'', b'', b'', b'', b'data']
-
-        def read_return(*args, **kwargs):
-            if args:
-                return read_return_tar_chunks.pop()
-            else:
-                return 'Package: foo\nPackage: bar'
-
-        mock_os_path_getsize.return_value = 0
-        tempdir = Mock()
-        tempdir.name = 'tmpdir'
-        mock_TemporaryDirectory.return_value = tempdir
-        mock_os_path_exists.return_value = True
-        mock_os_path_isdir.return_value = True
-        mock_yaml_safe_load.return_value = {
-            'Source': 'curl',
-            'Architecture': 'any',
-            'Maintainer': 'user@example.org',
-            'Build-Depends': 'a;native, b, c',
-            'Section': 'section',
-            'Priority': 'priority'
-        }
-        with patch('builtins.open', create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            file_handle = mock_open.return_value.__enter__.return_value
-            file_handle.readline.return_value = \
-                'curl (1:3.3.2-1) unstable; urgency=low'
-            file_handle.read.side_effect = read_return
-            file_handle.readlines.return_value = [
-                '# comment\n',
-                '  inline: ctrl-char\n',
-                'Package: foo\n',
-                'Package: bar'
-            ]
-            main()
-        assert mock_shutil_move.call_args_list == [
-            call('tmpdir/corbos/debian', 'tmpdir'),
-            call('tmpdir/corbos', 'tmpdir/curl-3.3.2')
-        ]
+        mock_Path.assert_called_once_with('obs_out')
+        mock_Path.return_value.mkdir.assert_called_once_with(
+            parents=True, exist_ok=True
+        )
         assert mock_Command.run.call_args_list == [
             call(
                 [
-                    'git', 'clone',
-                    'https://git.launchpad.net/ubuntu/+source/curl',
-                    'tmpdir/corbos'
+                    'podman', 'pull',
+                    'registry.example.com/ubdevtools:latest'
                 ]
             ),
             call(
                 [
-                    'rm', '-rf', 'tmpdir/corbos/.git'
+                    'podman', 'run', '-v', 'obs_out:/tmp',
+                    '-ti', '--rm', 'ubdevtools:latest',
+                    'bash -c "cd /tmp && pull-debian-source '
+                    '--mirror some-mirror --distro ubuntu curl"'
                 ]
-            ),
-            call(
-                [
-                    'git', '-C', 'tmpdir/corbos', 'checkout', 'develop'
-                ]
-            ),
-            call(
-                [
-                    'tar', '-C', 'tmpdir',
-                    '-cJf', 'obs_out/curl_3.3.2-1.debian.tar.xz',
-                    'debian'
-                ]
-            ),
-            call(
-                [
-                    'tar', '-C', 'tmpdir',
-                    '-czf', 'obs_out/curl_3.3.2.orig.tar.gz',
-                    'curl-3.3.2'
-                ]
-            )
-        ]
-        assert file_handle.write.call_args_list == [
-            call('Architecture: any\n'),
-            call('Binary: foo,bar\n'),
-            call('Build-Depends: a:native, b, c\n'),
-            call('Format: 3.0 (quilt)\n'),
-            call('Maintainer: user@example.org\n'),
-            call('Package-List:\n'),
-            call(' foo deb section priority arch=any\n'),
-            call(' bar deb section priority arch=any\n'),
-            call('Source: curl\n'),
-            call('Testsuite: autopkgtest\n'),
-            call('Version: 1:3.3.2-1\n'),
-            call('Checksums-Sha1:\n'),
-            call(
-                ' da39a3ee5e6b4b0d3255bfef95601890afd80709 0 '
-                'curl_3.3.2.orig.tar.gz\n'
-            ),
-            call(
-                ' da39a3ee5e6b4b0d3255bfef95601890afd80709 0 '
-                'curl_3.3.2-1.debian.tar.xz\n'
-            ),
-            call('Checksums-Sha256:\n'),
-            call(
-                ' 3a6eb0790f39ac87c94f3856b2dd2c5d110e68116022'
-                '61a9a923d3bb23adc8b7 0 curl_3.3.2.orig.tar.gz\n'
-            ),
-            call(
-                ' e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b'
-                '934ca495991b7852b855 0 curl_3.3.2-1.debian.tar.xz\n'
-            ),
-            call('Files:\n'),
-            call(
-                ' d41d8cd98f00b204e9800998ecf8427e 0 '
-                'curl_3.3.2.orig.tar.gz\n'
-            ),
-            call(
-                ' d41d8cd98f00b204e9800998ecf8427e 0 '
-                'curl_3.3.2-1.debian.tar.xz\n'
             )
         ]


### PR DESCRIPTION
All tools needed are available in the ubuntu-dev-tools
package. However, these tools are supposed to run in a
Debian environment. Because of this the obs service fetches
an application container providing ubuntu-dev-tools and
calls the relevant fetcher through podman. This allows
to make use of service in obs independently of the distribution
used for the OBS server. This Fixes #2