### PR TITLE
Use apt source for fetching sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build: clean tox
 	# restore original setup.py backed up from sed
 	mv setup.pye setup.py
 	# provide rpm source tarball
-	mv dist/corbos_scm-${version}.tar.gz dist/python-corbos_scm.tar.gz
+	mv dist/corbos_scm-${version}.tar.gz dist/python-corbos-scm.tar.gz
 	# update rpm changelog using reference file
 	helper/update_changelog.py --since package/python-corbos_scm.changes > \
 		dist/python-corbos_scm.changes

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ the `curl` package from Debian for Ubuntu(20.10) in OBS.
 
    .. code:: xml
 
-      <repository name="xUbuntu_20.10">
-        <path project="Ubuntu:20.10" repository="universe"/>
+      <repository name="xUbuntu_21.04">
+        <path project="Ubuntu:21.04" repository="universe"/>
         <arch>x86_64</arch>
       </repository>
 
@@ -134,20 +134,3 @@ be effective on the remote backend of OBS, it's required to install
 it there. This is because obs creates a command call from the
 information provided in the `_service` file and issues that command
 on its remote backend.
-
-Along with the most simple `_service` file the following
-optional parameters exists:
-
-.. code:: xml
-
-   <param name="mirror">Preferred Mirror location</param>
-
-This setting allows to specify a specific mirror to look for
-the desired content.
-
-.. code:: xml
-
-   <param name="distribution">Pull from: debian, ubuntu</param>
-
-This setting allows to specify the distribution name to target
-the desired package content.

--- a/corbos_scm/corbos_scm.py
+++ b/corbos_scm/corbos_scm.py
@@ -21,20 +21,12 @@
 """
 Usage:
     corbos_scm --package=<name> --registry=<uri> --container=<name> --outdir=<obs_out>
-        [--mirror=<mirror>]
-        [--distribution=<name>]
     corbos_scm -h | --help
     corbos_scm --version
 
 Options:
     --package=<name>
         Name of package to fetch
-
-    --mirror=<mirror>
-        Preferred mirror(s)
-
-    --distribution=<name>
-        Pull from: debian, ubuntu
 
     --registry=<uri>
         Container registry URI
@@ -75,11 +67,11 @@ def main() -> None:
     )
 
     pull_debian_source = [
-        'cd', '/tmp', '&&', 'apt', 'update', '&&', 'apt', 'source'
+        'cd', '/mnt', '&&', 'apt', 'update', '&&',
+        'apt', 'source', args['--package'], '&&',
+        'find', '-maxdepth', '1', '-type', 'd', '-not', '-path', '.', '|',
+        'xargs', 'rm', '-rf'
     ]
-    pull_debian_source.append(
-        args['--package']
-    )
 
     # Create a safe symlink with regards to the volume
     # name limitations of podman. For sharing a directory
@@ -101,7 +93,7 @@ def main() -> None:
 
     Command.run(
         [
-            'podman', 'run', '--volume', f'{save_volume_file}:/tmp',
+            'podman', 'run', '--volume', f'{save_volume_file}:/mnt',
             '-ti', '--rm', args["--container"], 'bash', '-c',
             ' '.join(pull_debian_source)
         ]

--- a/corbos_scm/corbos_scm.py
+++ b/corbos_scm/corbos_scm.py
@@ -75,16 +75,8 @@ def main() -> None:
     )
 
     pull_debian_source = [
-        'cd', '/tmp', '&&', 'pull-debian-source', '--download-only'
+        'cd', '/tmp', '&&', 'apt', 'update', '&&', 'apt', 'source'
     ]
-    if args['--mirror']:
-        pull_debian_source.extend(
-            ['--mirror', args['--mirror']]
-        )
-    if args['--distribution']:
-        pull_debian_source.extend(
-            ['--distro', args['--distribution']]
-        )
     pull_debian_source.append(
         args['--package']
     )

--- a/corbos_scm/corbos_scm.service
+++ b/corbos_scm/corbos_scm.service
@@ -1,12 +1,6 @@
 <service name="corbos_scm">
   <summary>Compose Corbos Source into OBS package sources</summary>
   <description>The service takes packages sources from the given distro and puts them into the OBS project</description>
-  <parameter name="mirror">
-    <description>Preferred Mirror location</description>
-  </parameter>
-  <parameter name="distribution">
-    <description>Pull from: debian, ubuntu</description>
-  </parameter>
   <parameter name="package">
     <description>Package name</description>
     <required/>

--- a/package/python-corbos_scm-spec-template
+++ b/package/python-corbos_scm-spec-template
@@ -62,7 +62,7 @@ License:        MIT
 Packager:       Marcus Schaefer <marcus.schaefer@gmail.com>
 %endif
 Group:          %{pygroup}
-Source:         %{name}.tar.gz
+Source:         python-corbos-scm.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python%{python3_pkgversion}-%{develsuffix}

--- a/test/unit/corbos_scm_test.py
+++ b/test/unit/corbos_scm_test.py
@@ -21,10 +21,6 @@ class TestCorbosSCM:
             'ubdevtools:latest',
             '--package',
             'curl',
-            '--mirror',
-            'some-mirror',
-            '--distribution',
-            'ubuntu',
             '--outdir',
             'obs_out'
         ]
@@ -62,10 +58,11 @@ class TestCorbosSCM:
             ),
             call(
                 [
-                    'podman', 'run', '--volume', 'tmpdir/volume:/tmp',
+                    'podman', 'run', '--volume', 'tmpdir/volume:/mnt',
                     '-ti', '--rm', 'ubdevtools:latest',
                     'bash', '-c',
-                    'cd /tmp && apt update && apt source curl'
+                    'cd /mnt && apt update && apt source curl && '
+                    'find -maxdepth 1 -type d -not -path . | xargs rm -rf'
                 ]
             )
         ]

--- a/test/unit/corbos_scm_test.py
+++ b/test/unit/corbos_scm_test.py
@@ -65,8 +65,7 @@ class TestCorbosSCM:
                     'podman', 'run', '--volume', 'tmpdir/volume:/tmp',
                     '-ti', '--rm', 'ubdevtools:latest',
                     'bash', '-c',
-                    'cd /tmp && pull-debian-source --download-only '
-                    '--mirror some-mirror --distro ubuntu curl'
+                    'cd /tmp && apt update && apt source curl'
                 ]
             )
         ]


### PR DESCRIPTION
With the former pull-debian-source we were not clear from
were exactly it fetches sources. Also I was told apt source
plus a correct deb-src setup in sources.list is the preferred
way to fetch sources for a specific distribution. Thus this
commit is opened for testing this way